### PR TITLE
Enhance puzzle shortcode options

### DIFF
--- a/chess-puzzle-vision.php
+++ b/chess-puzzle-vision.php
@@ -6,29 +6,47 @@ Version: 1.0
 Author: TADLAOUI Hamza
 */
 
-function display_chess_puzzle() {
+function display_chess_puzzle( $atts = array() ) {
+    $atts = shortcode_atts(
+        array(
+            'width'       => '400',
+            'orientation' => 'auto',
+        ),
+        $atts,
+        'chess_puzzle'
+    );
+
     ob_start();
-	enqueue_chess_puzzle_scripts();
+        enqueue_chess_puzzle_scripts( $atts['orientation'] );
     ?>
-	<div id="chessboard"  style="width: 400px"></div>
+        <div id="chessboard" style="width: <?php echo esc_attr( $atts['width'] ); ?>px"></div>
     <?php
     return ob_get_clean();
 }
-add_shortcode('chess_puzzle', 'display_chess_puzzle');
+add_shortcode( 'chess_puzzle', 'display_chess_puzzle' );
 
-function enqueue_chess_puzzle_scripts() {
-	?>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.2/chess.js"></script><br>
-	<?php
-    wp_enqueue_script('chessboard-js', plugin_dir_url(__FILE__) . 'js/chessboard-1.0.0.min.js', array('jquery'), '1.0.0', true);
-    wp_enqueue_style('chessboard-css', plugin_dir_url(__FILE__) . 'css/chessboard-1.0.0.min.css');
-    
-    wp_enqueue_script('chess-puzzle-script', plugin_dir_url(__FILE__) . 'js/main.js', array('jquery', 'chessboard-js'), null, true);
+function enqueue_chess_puzzle_scripts( $orientation = 'auto' ) {
+    wp_enqueue_script(
+        'chessjs',
+        'https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.2/chess.js',
+        array(),
+        '0.10.2',
+        true
+    );
 
-	wp_localize_script('chess-puzzle-script', 'pluginParams', array(
-    'pieceThemeBase' => plugin_dir_url(__FILE__) . 'img/chesspieces/wikipedia/'
-));
+    wp_enqueue_script( 'chessboard-js', plugin_dir_url( __FILE__ ) . 'js/chessboard-1.0.0.min.js', array( 'jquery' ), '1.0.0', true );
+    wp_enqueue_style( 'chessboard-css', plugin_dir_url( __FILE__ ) . 'css/chessboard-1.0.0.min.css' );
 
+    wp_enqueue_script( 'chess-puzzle-script', plugin_dir_url( __FILE__ ) . 'js/main.js', array( 'jquery', 'chessboard-js', 'chessjs' ), null, true );
+
+    wp_localize_script(
+        'chess-puzzle-script',
+        'pluginParams',
+        array(
+            'pieceThemeBase' => plugin_dir_url( __FILE__ ) . 'img/chesspieces/wikipedia/',
+            'orientation'    => $orientation,
+        )
+    );
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -27,12 +27,15 @@ jQuery(document).ready(function($) {
 
 
         // Current FEN should now be the starting position for the puzzle
-        // Set orientation based on who is to move
-		var gameOrientation = (game.turn() === 'b') ? 'black' : 'white';
-		var solutionIndex = 0
+        // Set orientation based on who is to move or user preference
+        var gameOrientation = (game.turn() === 'b') ? 'black' : 'white';
+        if (pluginParams.orientation && pluginParams.orientation !== 'auto') {
+            gameOrientation = pluginParams.orientation;
+        }
+                var solutionIndex = 0
         var cfg = {
                 draggable: true,
-				orientation: gameOrientation,
+                                orientation: gameOrientation,
                 position: fen,
                 pieceTheme: pluginParams.pieceThemeBase + '{piece}.png',
                 onDrop: function(source, target) {


### PR DESCRIPTION
## Summary
- allow width and orientation customization via shortcode
- load chess.js via `wp_enqueue_script`
- respect user-chosen orientation on board

## Testing
- `node -v`
- `php -l chess-puzzle-vision.php` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ddaa47bc832697bce6bcc4bf05e3